### PR TITLE
Stop depending on GL 21.08

### DIFF
--- a/io.mrarm.mcpelauncher.json
+++ b/io.mrarm.mcpelauncher.json
@@ -4,7 +4,7 @@
     "runtime-version": "6.3",
     "sdk": "org.kde.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.llvm12"
+        "org.freedesktop.Sdk.Extension.llvm15"
     ],
     "base": "io.qt.qtwebengine.BaseApp",
     "base-version": "6.3",


### PR DESCRIPTION
I don't want mesa 21.3.9 installed in flatpak when it's 2023!!!

This probably won't fix it, but it's the only thing in here that seems sus