### PR TITLE
Release v0.11.4 via Buildbot

### DIFF
--- a/io.mrarm.mcpelauncher.json
+++ b/io.mrarm.mcpelauncher.json
@@ -100,7 +100,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/minecraft-linux/mcpelauncher-versiondb.git",
-                    "commit": "cb3b59d7f1343a2d9b88395b1efa97264abee063"
+                    "commit": "e5ce44c443841cd7b2eb20c822b9ae91ce0619ec"
                 }
             ]
         },
@@ -128,9 +128,9 @@
                     "-DLAUNCHER_ENABLE_GOOGLE_PLAY_LICENCE_CHECK=ON",
                     "-DLAUNCHER_DISABLE_DEV_MODE=OFF",
                     "-DFETCHCONTENT_SOURCE_DIR_GLFW3_EXT=glfw3_ext",
-                    "-DLAUNCHER_VERSION_NAME=v0.11.3",
-                    "-DLAUNCHER_VERSION_CODE=70",
-                    "-DLAUNCHER_CHANGE_LOG=<p>Sorry I do not remember what has changed</p>",
+                    "-DLAUNCHER_VERSION_NAME=v0.11.4",
+                    "-DLAUNCHER_VERSION_CODE=71",
+                    "-DLAUNCHER_CHANGE_LOG=<p>apple m-series macs are unable to use intel builds of the game, due to the macOS 14 update you have to switch to arm64, which may need manual changes to profiles and older versions of the game may no longer work at all</p><p>apple m-series macs should now be enrolled to the experimental native arm64 game client you may have to disable all dev options you might have been using</p><p>Fixed stabilty issues of text input changes of the previous update</p>",
                     "-DLAUNCHER_VERSIONDB_URL=https://raw.githubusercontent.com/minecraft-linux/mcpelauncher-versiondb/v0.11.x"
                 ]
             },
@@ -138,7 +138,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/minecraft-linux/mcpelauncher-ui-manifest.git",
-                    "commit": "a40ddb042d7dfcd8f6f7b480ca0404d8dc452b2d",
+                    "commit": "348a805a44b1fb692af6bd5a131d18f98f4ecd4e",
                     "disable-shallow-clone": true
                 },
                 {
@@ -200,13 +200,13 @@
                 {
                     "type": "git",
                     "url": "https://github.com/minecraft-linux/mcpelauncher-manifest.git",
-                    "commit": "62732508615a499d2c1167a19e80441d13ed234f",
+                    "commit": "b4153480955ca1036b9850630919abeda8682774",
                     "disable-shallow-clone": true
                 },
                 {
                     "type": "git",
                     "url": "https://github.com/gabomdq/SDL_GameControllerDB",
-                    "commit": "f83dfc6e4925364f6489fc361627d435a125b50f",
+                    "commit": "55f1a1509f8f4a663c826ac8a572136ecfc13b53",
                     "dest": "gamecontrollerdb"
                 },
                 {

--- a/io.mrarm.mcpelauncher.metainfo.xml
+++ b/io.mrarm.mcpelauncher.metainfo.xml
@@ -55,6 +55,13 @@
         <content_attribute id="money-purchasing">intense</content_attribute>
     </content_rating>
     <releases>
+        <release version="v0.11.4" date="2023-10-07">
+            <description>
+                <p>apple m-series macs are unable to use intel builds of the game, due to the macOS 14 update you have to switch to arm64, which may need manual changes to profiles and older versions of the game may no longer work at all</p>
+                <p>apple m-series macs should now be enrolled to the experimental native arm64 game client you may have to disable all dev options you might have been using</p>
+                <p>Fixed stabilty issues of text input changes of the previous update</p>
+            </description>
+        </release>
         <release version="v0.11.3" date="2023-09-27">
             <description>
                 <p>Sorry I do not remember what has changed</p>


### PR DESCRIPTION
<p>apple m-series macs are unable to use intel builds of the game, due to the macOS 14 update you have to switch to arm64, which may need manual changes to profiles and older versions of the game may no longer work at all</p><p>apple m-series macs should now be enrolled to the experimental native arm64 game client you may have to disable all dev options you might have been using</p><p>Fixed stabilty issues of text input changes of the previous update</p>