### PR TITLE
Revert "Bump kde sdk to 6.6"

### DIFF
--- a/io.mrarm.mcpelauncher.json
+++ b/io.mrarm.mcpelauncher.json
@@ -1,13 +1,13 @@
 {
     "id": "io.mrarm.mcpelauncher",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.6",
+    "runtime-version": "6.5",
     "sdk": "org.kde.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.llvm17"
+        "org.freedesktop.Sdk.Extension.llvm15"
     ],
     "base": "io.qt.qtwebengine.BaseApp",
-    "base-version": "6.6",
+    "base-version": "6.5",
     "command": "mcpelauncher-ui-qt",
     "cleanup": [
         "*.a",
@@ -187,8 +187,8 @@
                     "-DOWN_CURL_SOURCE_DIR=curl_ext",
                     "-DCURL_EXT_EXTRA_OPTIONS=-DCURL_USE_LIBPSL=OFF"
                 ],
-                "prepend-path": "/usr/lib/sdk/llvm17/bin",
-                "prepend-ld-library-path": "/usr/lib/sdk/llvm17/lib"
+                "prepend-path": "/usr/lib/sdk/llvm15/bin",
+                "prepend-ld-library-path": "/usr/lib/sdk/llvm15/lib"
             },
             "only-arches": [
                 "i386",


### PR DESCRIPTION
Reverts flathub/io.mrarm.mcpelauncher#127

`mcpelauncher-webview https://google.de xbl://test` shows a white screen.

```
[2:2:1101/005934.761771:ERROR:zygote_linux.cc(277)] Unexpected real PID message from browser
[2:2:1101/005934.761934:ERROR:(-1)] Check failed: false. 
[4:48:1101/005935.385146:ERROR:zygote_communication_linux.cc(159)] Did not receive ping from zygote child
[4:48:1101/005935.385183:ERROR:(-1)] Check failed: false. 
[2:2:1101/005935.385239:ERROR:zygote_linux.cc(277)] Unexpected real PID message from browser
[3:3:1101/005935.385173:FATAL:zygote_linux.cc(467)] Failed to synchronise with parent zygote process
[2:2:1101/005935.385312:ERROR:(-1)] Check failed: false.
```

Google login works...