### PR TITLE
Disable QML Disk Cache due to loading old QML Content

### DIFF
--- a/io.mrarm.mcpelauncher.json
+++ b/io.mrarm.mcpelauncher.json
@@ -51,7 +51,8 @@
         "--env=ALSA_CONFIG_PATH=",
         "--env=QT_QUICK_CONTROLS_STYLE=",
         "--env=QT_QUICK_CONTROLS_HOVER_ENABLED=1",
-        "--env=QML_IMPORT_PATH=/app/qml/"
+        "--env=QML_IMPORT_PATH=/app/qml/",
+        "--env=QML_DISABLE_DISK_CACHE=1"
     ],
     "modules": [
         {


### PR DESCRIPTION
QT6 does not seem to detect that the disk cache is outdated

Closes https://github.com/flathub/io.mrarm.mcpelauncher/issues/412