### PR TITLE
Add QT_QPA_PLATFORMTHEME environment variable to avoid KDE Platform Theme

### DIFF
--- a/io.mrarm.mcpelauncher.json
+++ b/io.mrarm.mcpelauncher.json
@@ -52,7 +52,8 @@
         "--env=QT_QUICK_CONTROLS_STYLE=",
         "--env=QT_QUICK_CONTROLS_HOVER_ENABLED=1",
         "--env=QML_IMPORT_PATH=/app/qml/",
-        "--env=QML_DISABLE_DISK_CACHE=1"
+        "--env=QML_DISABLE_DISK_CACHE=1",
+        "--env=QT_QPA_PLATFORMTHEME=gtk3"
     ],
     "modules": [
         {


### PR DESCRIPTION
* due to KDE theme being broken in profile editor
* reproducible under gnome via `flatpak run --env=QT_QPA_PLATFORMTHEME=kde io.mrarm.mcpelauncher`
* https://github.com/minecraft-linux/mcpelauncher-ui-manifest/issues/75#issuecomment-4235321344

Closes https://github.com/minecraft-linux/mcpelauncher-ui-manifest/issues/75