### PR TITLE
Fix protobuf + libzip build with CMake 4.x

### DIFF
--- a/io.mrarm.mcpelauncher.json
+++ b/io.mrarm.mcpelauncher.json
@@ -63,15 +63,24 @@
                     "type": "git",
                     "url": "https://github.com/protocolbuffers/protobuf.git",
                     "tag": "v3.12.3",
-                    "commit": "31ebe2ac71400344a5db91ffc13c4ddfb7589f92"
+                    "commit": "31ebe2ac71400344a5db91ffc13c4ddfb7589f92",
+                    "disable-submodules": true
                 }
+            ],
+            "buildsystem": "cmake-ninja",
+            "subdir": "cmake",
+            "config-opts": [
+                "-Dprotobuf_BUILD_TESTS=OFF",
+                "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
             ]
         },
         {
             "name": "libzip",
             "build-options": {
                 "config-opts": [
-                    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+                    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+                    "-DCMAKE_INSTALL_LIBDIR=lib"
                 ]
             },
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
## Background

CMake 4.x (shipped in current `freedesktop-sdk`) tightened policy version checks and changed install-dir defaults. Two existing modules in this manifest fail to build cleanly against it without explicit overrides:

* `protobuf` v3.12.3 — `CMakeLists.txt` declares `cmake_minimum_required(VERSION 3.1.3)`, which CMake 4.x rejects with a hard error
* `libzip` v1.7.1 — `GNUInstallDirs` picks `lib64` on 64-bit Linux, but the KDE Platform 6.10 prefix expects libraries in `/app/lib`, breaking subsequent linkers

## Changes

**protobuf:**
- Switch to `cmake-ninja` buildsystem with `subdir: cmake` (upstream protobuf's CMake build files live under `cmake/`, not the repo root)
- `disable-submodules: true` on the git source — the v3.12.3 tag pulls in `google/benchmark`, `googletest`, and other deps that aren't used in this build and slow the fetch significantly
- `-Dprotobuf_BUILD_TESTS=OFF` — skip tests we don't run
- `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` — protobuf is consumed as a static lib by modules that build shared output
- `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` — gets past the cmake_minimum_required check

**libzip:**
- `-DCMAKE_INSTALL_LIBDIR=lib` — match the KDE Platform prefix layout

## Notes

- These match what current upstream protobuf and libzip recipes already do in newer Flathub builds; this PR just brings `io.mrarm.mcpelauncher` in line.
- Doesn't bump any commit pins.
- No behavioral change for the resulting binaries.

Tested by running `flatpak-builder --user --install --force-clean --install-deps-from=flathub --ccache build-dir io.mrarm.mcpelauncher.json` against current `freedesktop-sdk` 25.08; build now completes cleanly through to install. Without this change, both protobuf and libzip stages fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)